### PR TITLE
feat(health): pause polling after consecutive failures with Resume CTA

### DIFF
--- a/src/__tests__/AuthBootstrap.test.tsx
+++ b/src/__tests__/AuthBootstrap.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../state/auth/auth-context';
+import Me from '../pages/Me';
+
+// Verifies that authenticated bootstrap sets user and renders protected content
+
+describe('Auth bootstrap (happy path)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith('/api/me')) {
+        return new Response(JSON.stringify({ id: 'u1', email: 'user@example.com' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('not found', { status: 404 });
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('renders ME page after bootstrap without redirect', async () => {
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={[{ pathname: '/me' }]}>
+          <Routes>
+            <Route path="/me" element={<Me />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    expect(await screen.findByText(/My Account/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/HealthCheckCard.test.tsx
+++ b/src/__tests__/HealthCheckCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import HealthCheckCard from '../components/HealthCheckCard';
 
 // Simple smoke test: component mounts, shows initial state, then transitions to OK after mock fetch
@@ -24,5 +24,32 @@ describe('HealthCheckCard', () => {
     expect(await screen.findByTestId('health-card')).toBeInTheDocument();
     expect(await screen.findByText(/Healthy/i)).toBeInTheDocument();
     expect(await screen.findByText(/status: UP/i)).toBeInTheDocument();
+  });
+
+  it('pauses after consecutive failures and resumes on click', async () => {
+    // First three fetches fail, then succeed
+    vi.restoreAllMocks();
+    const fail = new Response('bad', { status: 500, headers: { 'Content-Type': 'text/plain' } }) as unknown as Response;
+    const ok = new Response(JSON.stringify({ status: 'UP' }), { status: 200, headers: { 'Content-Type': 'application/json' } }) as unknown as Response;
+    const fetchSpy = vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(ok);
+
+  render(<HealthCheckCard intervalMs={100000} minSkeletonMs={0} failureThreshold={3} />);
+
+  // Initial mount triggers first failure; click refresh twice for 2 more
+  await screen.findByRole('alert'); // error alert present
+  const refreshBtn = screen.getByRole('button', { name: /refresh now/i });
+  fireEvent.click(refreshBtn);
+  fireEvent.click(refreshBtn);
+
+  await waitFor(() => expect(screen.getByTestId('health-paused')).toBeInTheDocument());
+  expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    // Resume should trigger an immediate fetch and show healthy
+    fireEvent.click(screen.getByTestId('resume-btn'));
+    expect(await screen.findByText(/Healthy/i)).toBeInTheDocument();
   });
 });

--- a/src/components/HealthCheckCard.tsx
+++ b/src/components/HealthCheckCard.tsx
@@ -9,6 +9,7 @@ interface HealthCheckCardProps {
   intervalMs?: number;         // auto refresh interval
   minSkeletonMs?: number;      // minimum time skeleton remains
   onStatusChange?: (status: string) => void; // optional callback
+  failureThreshold?: number;   // consecutive failures before auto-pausing
 }
 
 type HealthState = 'idle' | 'checking' | 'ok' | 'error';
@@ -18,6 +19,7 @@ export function HealthCheckCard({
   intervalMs,
   minSkeletonMs = 450,
   onStatusChange,
+  failureThreshold = 3,
 }: HealthCheckCardProps) {
   const envInterval = (() => {
     if (intervalMs) return intervalMs;
@@ -32,8 +34,12 @@ export function HealthCheckCard({
   const [message, setMessage] = useState('');
   const [lastChecked, setLastChecked] = useState<number | undefined>();
   const checkStartRef = useRef<number | null>(null);
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const intervalIdRef = useRef<number | null>(null);
 
   const runHealthCheck = useCallback(async () => {
+    if (paused) return; // prevent background checks while paused
     setStatus(prev => (prev === 'idle' ? prev : 'checking'));
     checkStartRef.current = Date.now();
     try {
@@ -44,27 +50,50 @@ export function HealthCheckCard({
       } else {
         setMessage('Backend responded ✔');
       }
+      setConsecutiveFailures(0);
     } catch (e) {
       const err = e instanceof Error ? e : undefined;
       setStatus('error');
       setMessage(err?.message ?? 'Failed to reach backend');
+      setConsecutiveFailures(prev => {
+        const next = prev + 1;
+        if (next >= failureThreshold) {
+          setPaused(true);
+        }
+        return next;
+      });
     } finally {
       const end = Date.now();
       const elapsed = checkStartRef.current ? end - checkStartRef.current : 0;
       const delay = statusRef.current === 'checking' && elapsed < minSkeletonMs ? minSkeletonMs - elapsed : 0;
       setTimeout(() => setLastChecked(Date.now()), delay);
     }
-  }, [path, minSkeletonMs]);
+  }, [path, minSkeletonMs, paused, failureThreshold]);
 
   useEffect(() => { onStatusChange?.(status); }, [status, onStatusChange]);
 
   useEffect(() => {
-    // Run once on mount then on the interval; stable because runHealthCheck deps exclude status
+    // Run once on mount then on the interval; pause disables interval
     let cancelled = false;
     (async () => { if (!cancelled) await runHealthCheck(); })();
-    const id = setInterval(() => { if (!cancelled) runHealthCheck(); }, envInterval);
-    return () => { cancelled = true; clearInterval(id); };
-  }, [envInterval, runHealthCheck]);
+    if (!paused) {
+      const id = window.setInterval(() => { if (!cancelled) runHealthCheck(); }, envInterval);
+      intervalIdRef.current = id;
+    }
+    return () => {
+      cancelled = true;
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
+        intervalIdRef.current = null;
+      }
+    };
+  }, [envInterval, runHealthCheck, paused]);
+
+  const handleResume = useCallback(async () => {
+    setPaused(false);
+    setConsecutiveFailures(0);
+    await runHealthCheck();
+  }, [runHealthCheck]);
 
   return (
   <Card data-testid='health-card'>
@@ -99,16 +128,25 @@ export function HealthCheckCard({
                 <Code fontSize='xs'>{message}</Code>
               </HStack>
             )}
-            {status === 'error' && (
+            {status === 'error' && !paused && (
               <Alert status='error' variant='subtle'>
                 <AlertIcon /> <span>Error — <Code fontSize='xs'>{message}</Code></span>
+              </Alert>
+            )}
+            {paused && (
+              <Alert status='warning' variant='subtle' data-testid='health-paused'>
+                <AlertIcon />
+                <Flex align='center' gap={2} wrap='wrap'>
+                  <Text>Paused after {consecutiveFailures} consecutive failures.</Text>
+                  <Button size='xs' onClick={handleResume} data-testid='resume-btn'>Resume</Button>
+                </Flex>
               </Alert>
             )}
           </motion.div>
         </AnimatePresence>
         <HStack justify='space-between' pt={3} fontSize='xs' opacity={0.75} flexWrap='wrap'>
           <Text>{lastChecked ? `Last check: ${new Date(lastChecked).toLocaleTimeString()}` : 'Awaiting first result…'}</Text>
-          <Button size='xs' variant='outline' onClick={runHealthCheck} isDisabled={status==='idle'}>Refresh now</Button>
+          <Button size='xs' variant='outline' onClick={runHealthCheck} isDisabled={status==='idle' || paused}>Refresh now</Button>
         </HStack>
         <Text mt={2} fontSize='xs' opacity={0.6}>
           If this fails in dev, ensure the backend is running and CORS allows <Code fontSize='xs'>http://localhost:5173</Code>. If you use Actuator defaults, switch the fetch path to <Code fontSize='xs'>/actuator/health</Code>.


### PR DESCRIPTION
This pull request adds a new auto-pausing feature to the `HealthCheckCard` component, improving its robustness against consecutive backend failures. When the health check fails a configurable number of times in a row, the component will pause further checks and prompt the user to manually resume. Associated tests have been updated to verify this behavior.

**HealthCheckCard component enhancements:**

* Added a `failureThreshold` prop to `HealthCheckCard`, allowing configuration of how many consecutive failures will trigger auto-pausing. Default is 3. [[1]](diffhunk://#diff-848f163c6a8c8ec98a7c5e8e3e338cabb3669e284a8e820f68901d06f95f7927R12) [[2]](diffhunk://#diff-848f163c6a8c8ec98a7c5e8e3e338cabb3669e284a8e820f68901d06f95f7927R22)
* Implemented state tracking for consecutive failures and a `paused` state. When the failure threshold is reached, health checks are paused and the user is notified with an option to resume. [[1]](diffhunk://#diff-848f163c6a8c8ec98a7c5e8e3e338cabb3669e284a8e820f68901d06f95f7927R37-R42) [[2]](diffhunk://#diff-848f163c6a8c8ec98a7c5e8e3e338cabb3669e284a8e820f68901d06f95f7927R53-R96) [[3]](diffhunk://#diff-848f163c6a8c8ec98a7c5e8e3e338cabb3669e284a8e820f68901d06f95f7927L102-R149)
* Disabled the "Refresh now" button while paused to prevent further health checks until the user resumes.

**Testing improvements:**

* Added a test to `HealthCheckCard.test.tsx` to verify auto-pausing after consecutive failures and resuming on user action.
* Imported necessary testing utilities (`fireEvent`, `waitFor`) for simulating user interaction in the new test.

Closes issue #22 and #32 