### PR TITLE
fix(health): restart auto-polling after Resume; stabilize test timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,33 +9,43 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 - SECURITY policy (`SECURITY.md`).
 - MIT license file (`LICENSE`).
-- Coverage badge workflow (`coverage-badge.yml`) generating `coverage.svg` on main pushes.
+- Coverage badge workflow (`coverage-badge.yml`) that:
+	- runs tests with coverage on pull requests targeting `main` (no pushes),
+	- generates and commits a badge to `.github/badges/coverage.svg` only on pushes to `main`,
+	- uploads coverage artifacts on PRs for review.
 - `.env.example` template enumerating supported environment variables.
 - Dependabot configuration skeleton (`.github/dependabot.yml`) grouping security vs tooling updates.
 - Smoke test for `HealthCheckCard` component.
+ - Pause-on-error health polling with Resume CTA, plus tests covering pause/resume behavior.
 
 ### Changed
 - Replaced ad-hoc inline Home page health logic with reusable `<HealthCheckCard />` component.
 - Removed transient auth bootstrap "heartbeat" interval (was only for earlier debugging) to reduce console noise.
 - Stabilized health polling implementation (single interval; eliminated status-driven re-subscribe loop).
+ - README coverage badge now references the generated SVG in-repo and links to the workflow.
+ - Vitest coverage provider switched to `@vitest/coverage-v8` and scoped to `src/**` files.
 
 ### Fixed
 - Excessive `/actuator/health` polling spam caused by effect dependency loop and duplicate Home page implementation.
+- HealthCheckCard now restarts auto-polling after clicking Resume (previously stayed paused with no interval until manual refresh).
+- HealthCheckCard tests stabilized (no giant timers; deterministic pause/resume flow).
 
 ### Documentation
 - Added minimal security policy document.
-- README badges (release, coverage, security, license). 
+- README badges (release, coverage, security, license); added performance budget notes and live app links.
+- Developer docs updated to reflect coverage thresholds and PR coverage workflow.
 
 ### Security
 - Bump esbuild to 0.25.10 resolving moderate advisory.
-- Upgrade vitest to 3.2.4 (dev dependency; no runtime impact).
+- Upgrade Vitest to 3.2.4 and enable v8 coverage provider.
 
 ### Internal
 - Removed legacy .eslintignore by migrating ignore patterns to flat config.
 - Silenced auth debug logs during Vitest via `isVitest` guard.
-- Automated coverage badge generation.
+- Automated coverage badge generation with branch-protection-safe push step.
 - Refactored health polling to use stable callback + ref tracking (`statusRef`) preventing rapid interval churn.
 - Consolidated health checks (Home now delegates to `HealthCheckCard`).
+ - Ignore local `coverage/` directory in git; upload artifacts in CI instead.
 
 ### Notes
 - Nothing yet.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pre-1.0 releases use `0.x.y`; breaking changes may occur between minor bumps. Ea
 | Language         | TypeScript ^5.8.0 (strict)         | `noUncheckedSideEffectImports`, `verbatimModuleSyntax` enforced |
 | Linting          | ESLint flat config + plugins       | React Hooks, Refresh, a11y, import sorting                      |
 | Conventional commits | commitlint + Husky hooks       | Enforces `type(scope?): subject` style                          |
-| CI               | GitHub Actions                     | Lint, type, tests (coverage ≥50%), changelog check, build       |
+| CI               | GitHub Actions                     | Lint, type, tests; coverage (PRs, ≥50%); changelog check; build |
 | Release utility  | Custom script `npm run release`    | Bumps version + moves `[Unreleased]` in CHANGELOG               |
 
 ## Project Structure
@@ -173,11 +173,12 @@ Remove or disable this panel for production builds (guarded by `import.meta.env.
 ### Running Tests & Coverage
 
 ```bash
-npm run test          # Single run with coverage thresholds (50%)
+npm run test          # Single run
+npm run test:coverage # Run with v8 provider; thresholds (50%) enforced locally
 npx vitest watch      # Interactive watch (coverage summary on exit)
 ```
 
-Coverage thresholds (initial baseline): lines/functions/statements/branches ≥ 50%. CI fails below.
+Coverage thresholds (initial baseline): lines/functions/statements/branches ≥ 50%. PRs run coverage; CI fails below.
 
 ### Test Locations
 
@@ -226,7 +227,7 @@ vi.spyOn(global, "fetch").mockResolvedValueOnce(
 
 -   TypeScript clean (build runs `tsc -b`).
 -   ESLint passes (`npm run lint`).
--   Tests pass with coverage ≥ thresholds.
+-   Tests pass; coverage ≥ thresholds.
 -   Changelog updated when source/docs change (`npm run changelog:check`).
 -   Conventional commit style enforced (Husky + commitlint).
 -   CI replicates local gates: lint → type → tests → changelog check → build.
@@ -258,7 +259,8 @@ npm run build
 -   dev – start Vite dev server
 -   build – production build
 -   preview – preview production build locally
--   test – run Vitest suite (with coverage thresholds)
+-   test – run Vitest suite
+-   test:coverage – run Vitest with @vitest/coverage-v8 (thresholds enforced)
 -   release – run automated version + changelog update script
 -   changelog:check – enforce changelog entry presence
 -   lint / lint:fix – run (and optionally fix) ESLint
@@ -275,3 +277,7 @@ git fetch origin --prune
 ```
 
 CI badge & links have been updated to the new organization path.
+
+## Notes
+
+- Local coverage artifacts (coverage/) are ignored by git; the CI workflow uploads coverage as PR artifacts and updates the badge on main after merge.

--- a/TTD.md
+++ b/TTD.md
@@ -42,3 +42,37 @@
 ## Notes
 
 Add new sections here as areas expand (e.g., Testing, Performance, Accessibility).
+
+
+### Potential workflow--for badge coverage updating:
+
+name: Update Badge
+on:
+  workflow_run:
+    workflows: ["CI"]   # or on: push: branches: [main]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TODO: generate/update your badge/readme here
+      - run: |
+          ./scripts/update-badge.sh
+          git status --porcelain || true
+
+      # Use peter-evans/create-pull-request to open/refresh a PR
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(badge): update status badge"
+          branch: badges/auto
+          title: "chore(badge): update status badge"
+          body: "Automated badge update."
+          signoff: false
+          delete-branch: false   # keep or auto-delete after merge if you prefer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,9 +48,10 @@ Planning references:
 ## Build & CI
 
 -   Command chain: `npm run build` → `tsc -b` (type check only) → `vite build` (bundle & optimize).
--   CI pipeline order: lint → typecheck → test (Vitest, coverage ≥50%) → changelog check → build → artifacts.
+-   CI pipeline order: lint → typecheck → test (Vitest) → coverage (PRs) → changelog check → build → artifacts.
 -   Changelog enforcement: script fails CI if source changes without `CHANGELOG.md` update.
 -   Conventional commits enforced locally via Husky + commitlint.
+-   Coverage provider: @vitest/coverage-v8 with thresholds ≥ 50% (scoped to src/**/*).
 -   Release automation script (`npm run release`) bumps version, migrates `[Unreleased]`, updates diff links, commits (+ optional tag).
 
 ## Extension Points

--- a/docs/developer-workflow-checklist.md
+++ b/docs/developer-workflow-checklist.md
@@ -42,6 +42,7 @@ End-to-end repeatable steps for making, validating, and shipping a change. Use t
 -   [ ] Type check: `npm run typecheck` (or `npm run build` for full chain).
 -   [ ] Lint: `npm run lint` (fix issues or refactor).
 -   [ ] Tests: `npm test` (ensure green; add missing cases for new logic paths).
+-   [ ] Coverage: `npm run test:coverage` (thresholds: lines/functions/statements/branches ≥ 50%).
 -   [ ] Changelog enforcement: `npm run changelog:check` (ensures entry is present if source changed).
 
 ## 6. Commit & Push
@@ -57,7 +58,7 @@ End-to-end repeatable steps for making, validating, and shipping a change. Use t
 
 ## 8. CI Validation
 
--   [ ] Confirm CI passes: lint, typecheck, tests, changelog check, build.
+-   [ ] Confirm CI passes: lint, typecheck, tests, coverage on PR, changelog check, build.
 -   [ ] Address failures immediately (amend fix commits rather than stacking noise if early in review).
 
 ## 9. Review Iteration
@@ -130,6 +131,12 @@ Trigger this AFTER the PR containing the final set of changes for the release ha
 | Intermittent test failure        | Flaky timing waits       | Replace `setTimeout` with deterministic mock / use `waitFor` correctly |
 | Unused imports / types           | Lint errors              | Remove or use                                                          |
 | Accidental double bootstrap logs | Extra refresh calls      | Confirm module-level guard intact in auth context                      |
+
+---
+
+## TODO (Next Improvements)
+
+- Write coverage percentage to the GitHub Actions job summary on PRs so reviewers see it without downloading artifacts.
 
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,16 @@
+# Proxy /api/* to the backend (keeps cookies same-origin for credentials:'include')
 [[redirects]]
 from = "/api/*"
-to = "https://api-sameboat.onrender.com//:splat"
+to = "https://api-sameboat.onrender.com/:splat"
 status = 200
 force = true
+
+# Security headers
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; connect-src 'self'; img-src 'self' data: https:; font-src 'self' data:; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; upgrade-insecure-requests"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"


### PR DESCRIPTION
### Summary
- After pausing on consecutive failures, HealthCheckCard didn’t automatically restart its interval when the user clicked Resume. Also, the test relied on brittle timer behavior.

### What changed
- Resume auto-polling:
    - Added a ref-backed paused guard to avoid stale closure inside the polling callback.
    - runHealthCheck now checks pausedRef.current, so immediate checks post-resume are not short-circuited.
    - The existing effect recreates the interval when paused toggles back to false; handleResume triggers an immediate health check.
- Test stabilization:
    - Reworked the pause/resume test to use manual Refresh clicks (long interval) instead of large timers; added an extra OK response to avoid race.
    
### Why
- Ensures the component behaves intuitively after the user resumes and keeps tests deterministic and fast.

### How to verify
- npm run test
- In the UI: induce 3 failures (or simulate), observe Paused alert, click Resume; status returns to OK and auto-polling resumes.

### Linked issues
- Closes #38 

### Scope/impact
- Files:
    - [HealthCheckCard.tsx](vscode-file://vscode-app/c:/Users/nickh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    - [HealthCheckCard.test.tsx](vscode-file://vscode-app/c:/Users/nickh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
No API or public prop changes.

### Notes
- Manual Refresh remains disabled while paused.
- Interval is recreated only when unpaused; we also issue an immediate check on Resume for snappy feedback.